### PR TITLE
First MCP Tool - create_project (#4)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,7 @@ import {
 } from '@modelcontextprotocol/sdk/types.js';
 import { loadConfig } from './utils/config.js';
 import { initializeDatabase } from './storage/db.js';
+import { createProjectTool, type CreateProjectParams } from './tools/create-project.js';
 import type { Config } from './types/index.js';
 
 /**
@@ -64,8 +65,30 @@ async function main() {
   server.setRequestHandler(ListToolsRequestSchema, async () => {
     return {
       tools: [
-        // TODO: Add tools in subsequent issues
-        // - create_project (Issue #4)
+        {
+          name: 'create_project',
+          description: 'Create a new project with Obsidian directory and database entry',
+          inputSchema: {
+            type: 'object',
+            properties: {
+              projectName: {
+                type: 'string',
+                description: 'Name of the project',
+              },
+              description: {
+                type: 'string',
+                description: 'Project description (optional)',
+              },
+              conversationMode: {
+                type: 'boolean',
+                description: 'Enable conversational ideation (optional, will be implemented in Issue #25)',
+                default: false,
+              },
+            },
+            required: ['projectName'],
+          },
+        },
+        // TODO: Add more tools in subsequent issues
         // - analyze_git_commits (Issue #8)
         // - log_daily_work (Issue #7)
         // - extract_insights (Issue #11)
@@ -78,10 +101,37 @@ async function main() {
 
   // Register tool call handler
   server.setRequestHandler(CallToolRequestSchema, async (request) => {
-    const { name } = request.params;
+    const { name, arguments: args } = request.params;
 
-    // TODO: Implement tool handlers in subsequent issues
-    throw new Error(`Unknown tool: ${name}`);
+    try {
+      if (name === 'create_project') {
+        const params = (args || {}) as unknown as CreateProjectParams;
+        const result = await createProjectTool(params, config);
+
+        return {
+          content: [
+            {
+              type: 'text',
+              text: result.message,
+            },
+          ],
+        };
+      }
+
+      // TODO: Implement more tool handlers in subsequent issues
+      throw new Error(`Unknown tool: ${name}`);
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      return {
+        content: [
+          {
+            type: 'text',
+            text: `Error: ${errorMessage}`,
+          },
+        ],
+        isError: true,
+      };
+    }
   });
 
   // Register resource list handler

--- a/src/tools/create-project.ts
+++ b/src/tools/create-project.ts
@@ -1,0 +1,132 @@
+/**
+ * MCP Tool: create_project
+ *
+ * Creates a new project with:
+ * - Obsidian directory and README
+ * - SQLite metadata entry
+ * - Optional conversational ideation
+ */
+
+import { mkdirSync, writeFileSync, existsSync } from 'fs';
+import { resolve, join } from 'path';
+import Mustache from 'mustache';
+import { readFileSync } from 'fs';
+import { createProject } from '../storage/db.js';
+import type { Config } from '../types/index.js';
+
+export interface CreateProjectParams {
+  projectName: string;
+  description?: string;
+  conversationMode?: boolean;
+}
+
+export interface CreateProjectResult {
+  projectId: string;
+  obsidianPath: string;
+  notionPageId?: string;
+  message: string;
+}
+
+/**
+ * Create a new project
+ */
+export async function createProjectTool(
+  params: CreateProjectParams,
+  config: Config
+): Promise<CreateProjectResult> {
+  const { projectName, description, conversationMode } = params;
+
+  // Validate project name
+  if (!projectName || projectName.trim().length === 0) {
+    throw new Error('Project name is required');
+  }
+
+  const sanitizedName = sanitizeName(projectName);
+  const createdDate = new Date().toISOString();
+
+  // Create Obsidian directory
+  const obsidianPath = createObsidianProject(
+    config.obsidian.vaultPath,
+    sanitizedName,
+    projectName,
+    description || '',
+    createdDate
+  );
+
+  // Create database entry
+  const projectId = createProject({
+    name: projectName,
+    description,
+    createdDate,
+    obsidianPath,
+  });
+
+  // TODO: Create Notion database in Issue #24
+  const notionPageId = undefined;
+
+  // TODO: Implement conversation mode in Issue #25
+  if (conversationMode) {
+    console.error('Note: Conversation mode will be implemented in Issue #25');
+  }
+
+  return {
+    projectId,
+    obsidianPath,
+    notionPageId,
+    message: `Project "${projectName}" created successfully!\n- ID: ${projectId}\n- Obsidian: ${obsidianPath}`,
+  };
+}
+
+/**
+ * Create Obsidian project directory and README
+ */
+function createObsidianProject(
+  vaultPath: string,
+  sanitizedName: string,
+  displayName: string,
+  description: string,
+  createdDate: string
+): string {
+  // Create project directory
+  const projectPath = resolve(vaultPath, 'Projects', sanitizedName);
+
+  if (existsSync(projectPath)) {
+    throw new Error(`Project directory already exists: ${projectPath}`);
+  }
+
+  mkdirSync(projectPath, { recursive: true });
+
+  // Create Daily Logs subdirectory
+  const dailyLogsPath = join(projectPath, 'Daily Logs');
+  mkdirSync(dailyLogsPath, { recursive: true });
+
+  // Load and render template
+  const templatePath = resolve(process.cwd(), 'templates/obsidian/project.md');
+  const template = readFileSync(templatePath, 'utf-8');
+
+  const rendered = Mustache.render(template, {
+    name: displayName,
+    description: description || 'No description provided',
+    createdDate,
+    notionUrl: 'TBD (will be added in Issue #24)',
+  });
+
+  // Write README
+  const readmePath = join(projectPath, 'README.md');
+  writeFileSync(readmePath, rendered, 'utf-8');
+
+  console.error(`  - Created Obsidian project at: ${projectPath}`);
+
+  return projectPath;
+}
+
+/**
+ * Sanitize project name for use as directory name
+ */
+function sanitizeName(name: string): string {
+  return name
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}

--- a/templates/obsidian/project.md
+++ b/templates/obsidian/project.md
@@ -1,0 +1,20 @@
+---
+project: {{name}}
+created: {{createdDate}}
+description: {{description}}
+tags: [project, retrospect]
+---
+
+# {{name}}
+
+## Overview
+
+{{description}}
+
+## Daily Logs
+
+- [[Daily Logs]]
+
+## Links
+
+- Notion: {{notionUrl}}


### PR DESCRIPTION
## Summary
Implemented the first MCP tool: create_project

## Changes

- Added Obsidian project template with Mustache
- Implemented create_project tool functionality
  - Creates Obsidian directory structure
  - Generates README from template
  - Saves metadata to SQLite database
  - Sanitizes project names
- Registered tool in MCP server
  - Tool definition with input schema
  - Tool call handler with error handling

## Features

- Creates project directory in Obsidian vault
- Generates README with project metadata  
- Creates Daily Logs subdirectory
- Saves to database with unique ID
- Returns project ID and paths

## Testing

- Tool tested successfully
- Obsidian directory and README created correctly
- Database entry verified

## Related Issues

Closes #4

Note: Notion integration will be added in Issue #24, conversation mode in Issue #25

Generated with Claude Code