### PR TITLE
Issue #13: SNS Formatter Prompts

### DIFF
--- a/src/prompts/sns-formatters.ts
+++ b/src/prompts/sns-formatters.ts
@@ -1,0 +1,210 @@
+/**
+ * SNS Formatter Prompts
+ *
+ * Platform-specific prompts for generating optimized SNS content
+ */
+
+export interface SNSPromptTemplate {
+  systemPrompt: string;
+  userPromptTemplate: string;
+}
+
+/**
+ * Thread (Twitter/X) Formatter Prompt
+ *
+ * Requirements:
+ * - 280 characters per tweet
+ * - Engaging hook in first tweet
+ * - Thread format (numbered if needed)
+ * - Clear, concise, actionable
+ */
+export const THREAD_FORMATTER_PROMPT: SNSPromptTemplate = {
+  systemPrompt: `You are an expert at creating engaging Twitter/X threads for software engineers.
+
+REQUIREMENTS:
+- Each tweet must be 280 characters or less
+- First tweet must have a compelling hook
+- Use simple, clear language
+- Include actionable takeaways
+- Use emojis sparingly (1-2 per tweet max)
+- No hashtags unless specifically requested
+- Maximum 5 tweets per thread
+
+STYLE:
+- Direct and conversational
+- Start with a problem or question
+- Build up to the insight
+- End with a clear takeaway
+
+OUTPUT FORMAT:
+Return a JSON array of tweet strings:
+["Tweet 1 text", "Tweet 2 text", ...]`,
+
+  userPromptTemplate: `Create a Twitter/X thread from this insight:
+
+{{insight}}
+
+Context: {{context}}
+
+Remember:
+- 280 characters per tweet
+- Engaging hook first
+- Maximum 5 tweets
+- Return JSON array of strings`,
+};
+
+/**
+ * LinkedIn Formatter Prompt
+ *
+ * Requirements:
+ * - 1300-1500 characters
+ * - Professional tone
+ * - Storytelling approach
+ * - Personal experience
+ */
+export const LINKEDIN_FORMATTER_PROMPT: SNSPromptTemplate = {
+  systemPrompt: `You are an expert at creating engaging LinkedIn posts for software engineers and technical professionals.
+
+REQUIREMENTS:
+- 1300-1500 characters total (not too long, not too short)
+- Professional yet approachable tone
+- Tell a story from personal experience
+- Include specific technical details
+- End with a question or call-to-action
+- Use line breaks for readability (2-3 sentence paragraphs)
+
+STRUCTURE:
+1. Hook: Start with a relatable problem or experience (2-3 sentences)
+2. Context: Explain what you were working on (2-3 sentences)
+3. Discovery: Share the insight and how you found it (3-4 sentences)
+4. Impact: What changed after applying this (2-3 sentences)
+5. Takeaway: Key lesson learned (1-2 sentences)
+6. Engagement: Question or call-to-action (1 sentence)
+
+STYLE:
+- First-person narrative ("I discovered", "We faced")
+- Balance technical depth with accessibility
+- Show vulnerability and learning
+- Avoid buzzwords and corporate speak
+
+OUTPUT FORMAT:
+Return plain text (not JSON), ready to post`,
+
+  userPromptTemplate: `Create a LinkedIn post from this insight:
+
+{{insight}}
+
+Context: {{context}}
+
+Remember:
+- 1300-1500 characters
+- Tell a story
+- Professional but personal
+- End with engagement question
+- Return plain text`,
+};
+
+/**
+ * Medium Formatter Prompt
+ *
+ * Requirements:
+ * - 800-1500 words
+ * - Markdown format
+ * - Code examples
+ * - Technical depth
+ */
+export const MEDIUM_FORMATTER_PROMPT: SNSPromptTemplate = {
+  systemPrompt: `You are an expert technical writer creating Medium articles for software engineers.
+
+REQUIREMENTS:
+- 800-1500 words (substantial but focused)
+- Markdown format with proper headings
+- Include code examples where relevant
+- Technical depth while remaining accessible
+- Clear structure with sections
+- No introduction fluff - get to the point quickly
+
+STRUCTURE:
+1. Title: Catchy but descriptive (not clickbait)
+2. Brief intro: The problem (1-2 paragraphs)
+3. Context: What led to the discovery (2-3 paragraphs)
+4. The Insight: Core learning with examples (4-6 paragraphs)
+5. Implementation: How to apply it (3-4 paragraphs with code)
+6. Results: What improved (1-2 paragraphs)
+7. Conclusion: Key takeaways (1 paragraph)
+
+CODE EXAMPLES:
+- Use markdown code blocks with language tags
+- Keep examples concise and focused
+- Add comments to explain key parts
+- Show before/after when relevant
+
+STYLE:
+- Clear, technical writing
+- Use subheadings for scanability
+- Include inline code for technical terms
+- Link to relevant documentation when appropriate
+- Use bullet points for lists
+
+OUTPUT FORMAT:
+Return markdown text with:
+- H1 for title (# Title)
+- H2 for main sections (## Section)
+- H3 for subsections (### Subsection)
+- Code blocks with language tags
+- Bold for emphasis
+- Inline code for technical terms`,
+
+  userPromptTemplate: `Create a Medium article from this insight:
+
+{{insight}}
+
+Context: {{context}}
+
+Remember:
+- 800-1500 words
+- Markdown format
+- Include code examples
+- Technical depth
+- Clear structure with sections
+- Return markdown text`,
+};
+
+/**
+ * Format insight for SNS prompt
+ */
+export function formatInsightForSNS(
+  insight: {
+    content: string;
+    category: string;
+    confidence: number;
+    context?: string;
+  },
+  platform: 'thread' | 'linkedin' | 'medium'
+): { systemPrompt: string; userPrompt: string } {
+  let template: SNSPromptTemplate;
+
+  switch (platform) {
+    case 'thread':
+      template = THREAD_FORMATTER_PROMPT;
+      break;
+    case 'linkedin':
+      template = LINKEDIN_FORMATTER_PROMPT;
+      break;
+    case 'medium':
+      template = MEDIUM_FORMATTER_PROMPT;
+      break;
+    default:
+      throw new Error(`Unknown platform: ${platform}`);
+  }
+
+  // Replace template variables
+  const userPrompt = template.userPromptTemplate
+    .replace('{{insight}}', insight.content)
+    .replace('{{context}}', insight.context || 'No additional context provided');
+
+  return {
+    systemPrompt: template.systemPrompt,
+    userPrompt,
+  };
+}


### PR DESCRIPTION
Implements platform-specific prompts for SNS content generation.

Changes:
- Add sns-formatters.ts with three platform prompts
- Thread (Twitter/X) Formatter:
  - 280 character limit per tweet
  - Engaging hook requirement
  - Maximum 5 tweets per thread
  - JSON array output format
  - Conversational and direct style
- LinkedIn Formatter:
  - 1300-1500 character target
  - Professional storytelling approach
  - 6-part structure (Hook, Context, Discovery, Impact, Takeaway, Engagement)
  - First-person narrative style
  - Plain text output
- Medium Formatter:
  - 800-1500 word article
  - Markdown format with proper headings
  - Code examples with syntax highlighting
  - 7-part structure with technical depth
  - Clear technical writing style
- Add formatInsightForSNS helper:
  - Template variable replacement
  - Platform-specific prompt selection
  - Returns system and user prompts

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>