### PR TITLE
Issue #15: generate_sns_post Tool

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,7 @@ import { createProjectTool, type CreateProjectParams } from './tools/create-proj
 import { logDailyWorkTool, type LogDailyWorkParams } from './tools/log-daily-work.js';
 import { analyzeCommitsTool, type AnalyzeCommitsParams } from './tools/analyze-commits.js';
 import { extractInsightsTool, type ExtractInsightsParams } from './tools/extract-insights.js';
+import { generateSNSTool, type GenerateSNSParams } from './tools/generate-sns.js';
 import { listInsightsResources, readInsightsResource } from './resources/insights.js';
 import type { Config } from './types/index.js';
 
@@ -177,8 +178,31 @@ async function main() {
             required: ['startDate', 'endDate'],
           },
         },
+        {
+          name: 'generate_sns_post',
+          description: 'Generate SNS content from insights for specified platforms',
+          inputSchema: {
+            type: 'object',
+            properties: {
+              insightId: {
+                type: 'string',
+                description: 'Insight ID to generate content from',
+              },
+              platform: {
+                type: 'string',
+                enum: ['thread', 'linkedin', 'medium'],
+                description: 'Target SNS platform',
+              },
+              includeHashtags: {
+                type: 'boolean',
+                description: 'Include auto-generated hashtags (default true)',
+                default: true,
+              },
+            },
+            required: ['insightId', 'platform'],
+          },
+        },
         // TODO: Add more tools in subsequent issues
-        // - generate_sns_post (Issue #15)
         // - approve_and_publish (Issue #20)
         // - extract_action_items (Issue #26)
       ],
@@ -235,6 +259,20 @@ async function main() {
       if (name === 'extract_insights') {
         const params = (args || {}) as unknown as ExtractInsightsParams;
         const result = await extractInsightsTool(params, config);
+
+        return {
+          content: [
+            {
+              type: 'text',
+              text: result.message,
+            },
+          ],
+        };
+      }
+
+      if (name === 'generate_sns_post') {
+        const params = (args || {}) as unknown as GenerateSNSParams;
+        const result = await generateSNSTool(params, config);
 
         return {
           content: [

--- a/src/tools/generate-sns.ts
+++ b/src/tools/generate-sns.ts
@@ -1,0 +1,149 @@
+/**
+ * MCP Tool: generate_sns_post
+ *
+ * Generates SNS content from insights for specified platforms
+ */
+
+import { generateContent } from '../core/content-generator.js';
+import { ClaudeClient } from '../utils/claude-client.js';
+import { getInsight, createSNSPost } from '../storage/db.js';
+import type { Config } from '../types/index.js';
+
+export interface GenerateSNSParams {
+  insightId: string;
+  platform: 'thread' | 'linkedin' | 'medium';
+  includeHashtags?: boolean;
+}
+
+export interface GenerateSNSResult {
+  postId: string;
+  platform: 'thread' | 'linkedin' | 'medium';
+  content: string | string[];
+  hashtags: string[];
+  status: string;
+  message: string;
+}
+
+/**
+ * Generate SNS post from insight
+ */
+export async function generateSNSTool(
+  params: GenerateSNSParams,
+  config: Config
+): Promise<GenerateSNSResult> {
+  const { insightId, platform, includeHashtags = true } = params;
+
+  // Get insight from database
+  const insight = getInsight(insightId);
+  if (!insight) {
+    throw new Error(`Insight not found: ${insightId}`);
+  }
+
+  console.error(`  - Generating ${platform} post for insight: ${insightId}`);
+
+  // Create Claude client
+  const claudeClient = new ClaudeClient({
+    apiKey: config.claude.apiKey,
+    model: config.claude.model,
+  });
+
+  // Generate content
+  const generated = await generateContent(
+    {
+      insight: {
+        id: insight.id,
+        content: insight.content,
+        category: insight.category,
+        confidence: insight.confidence,
+      },
+      platform,
+      includeHashtags,
+    },
+    claudeClient
+  );
+
+  // Save to pending_posts
+  const postId = createSNSPost({
+    insightId: insight.id,
+    platform,
+    content: generated.content,
+    status: 'pending',
+    version: 1,
+    metadata: {
+      hashtags: generated.hashtags,
+      ...generated.metadata,
+    },
+  });
+
+  console.error(`  - Created pending post: ${postId} (status: pending)`);
+
+  // Format message
+  const message = formatSNSPostMessage(postId, platform, generated);
+
+  return {
+    postId,
+    platform,
+    content: generated.content,
+    hashtags: generated.hashtags,
+    status: 'pending',
+    message,
+  };
+}
+
+/**
+ * Format SNS post message
+ */
+function formatSNSPostMessage(
+  postId: string,
+  platform: 'thread' | 'linkedin' | 'medium',
+  generated: {
+    content: string | string[];
+    hashtags: string[];
+    metadata: {
+      characterCount?: number;
+      wordCount?: number;
+      tweetCount?: number;
+    };
+  }
+): string {
+  const lines: string[] = [];
+
+  lines.push(`Generated ${platform} post!`);
+  lines.push(`Post ID: ${postId}`);
+  lines.push(`Status: pending (awaiting approval)`);
+  lines.push('');
+
+  // Platform-specific metadata
+  if (platform === 'thread') {
+    lines.push(`Tweet count: ${generated.metadata.tweetCount}`);
+    lines.push('');
+    lines.push('Preview:');
+    (generated.content as string[]).forEach((tweet, index) => {
+      lines.push(`${index + 1}. ${tweet.substring(0, 100)}${tweet.length > 100 ? '...' : ''}`);
+    });
+  } else if (platform === 'linkedin') {
+    lines.push(`Character count: ${generated.metadata.characterCount}`);
+    lines.push('');
+    lines.push('Preview:');
+    const preview = (generated.content as string).substring(0, 200);
+    lines.push(preview + (preview.length < (generated.content as string).length ? '...' : ''));
+  } else if (platform === 'medium') {
+    lines.push(`Word count: ${generated.metadata.wordCount}`);
+    lines.push('');
+    lines.push('Preview:');
+    const preview = (generated.content as string).substring(0, 200);
+    lines.push(preview + (preview.length < (generated.content as string).length ? '...' : ''));
+  }
+
+  // Hashtags
+  if (generated.hashtags.length > 0) {
+    lines.push('');
+    lines.push(`Hashtags: ${generated.hashtags.join(' ')}`);
+  }
+
+  lines.push('');
+  lines.push('Use the pending-posts resource to view full content.');
+  lines.push('Use approve_and_publish tool to approve and publish.');
+
+  return lines.join('\n');
+}


### PR DESCRIPTION
Implements MCP tool for generating SNS content from insights.

Changes:
- Add generate-sns.ts tool implementation
  - Get insight from database by ID
  - Create Claude client with config
  - Call content generator for specified platform
  - Save to pending_posts table with status='pending'
  - Return post ID, content preview, and metadata
- Register generate_sns_post tool in MCP server
  - Add tool schema with parameters
  - Add handler in CallToolRequestSchema
  - Support platform enum (thread, linkedin, medium)
- Tool workflow:
  - Input: insight ID + platform
  - Generate platform-optimized content
  - Store in pending_posts for approval
  - Return preview and post ID
- Result message includes:
  - Post ID for tracking
  - Platform-specific metadata
  - Content preview (first 100-200 chars)
  - Hashtags if included
  - Instructions for approval workflow

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>