### PR TITLE
Issue #16: pending-posts Resource

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,7 @@ import { analyzeCommitsTool, type AnalyzeCommitsParams } from './tools/analyze-c
 import { extractInsightsTool, type ExtractInsightsParams } from './tools/extract-insights.js';
 import { generateSNSTool, type GenerateSNSParams } from './tools/generate-sns.js';
 import { listInsightsResources, readInsightsResource } from './resources/insights.js';
+import { listPendingPostsResources, readPendingPostsResource } from './resources/pending-posts.js';
 import type { Config } from './types/index.js';
 
 /**
@@ -307,10 +308,12 @@ async function main() {
     // Add insights resources
     resources.push(...listInsightsResources());
 
+    // Add pending posts resources
+    resources.push(...listPendingPostsResources());
+
     // TODO: Add more resources in subsequent issues
     // - daily-logs:// (Issue #27)
     // - projects:// (Issue #27)
-    // - pending-posts:// (Issue #16)
 
     return { resources };
   });
@@ -323,6 +326,20 @@ async function main() {
       // Handle insights resources
       if (uri.startsWith('insights://')) {
         const content = readInsightsResource(uri);
+        return {
+          contents: [
+            {
+              uri,
+              mimeType: 'application/json',
+              text: content,
+            },
+          ],
+        };
+      }
+
+      // Handle pending posts resources
+      if (uri.startsWith('pending-posts://')) {
+        const content = readPendingPostsResource(uri);
         return {
           contents: [
             {

--- a/src/resources/pending-posts.ts
+++ b/src/resources/pending-posts.ts
@@ -1,0 +1,146 @@
+/**
+ * MCP Resource: pending-posts
+ *
+ * Provides access to pending SNS posts awaiting approval
+ */
+
+import { getPendingPosts, getSNSPost } from '../storage/db.js';
+
+/**
+ * List all pending posts resources
+ */
+export function listPendingPostsResources(): Array<{
+  uri: string;
+  name: string;
+  description: string;
+  mimeType: string;
+}> {
+  return [
+    {
+      uri: 'pending-posts://list',
+      name: 'Pending Posts',
+      description: 'List all pending SNS posts awaiting approval',
+      mimeType: 'application/json',
+    },
+  ];
+}
+
+/**
+ * Read pending posts resource
+ */
+export function readPendingPostsResource(uri: string): string {
+  // Parse URI: pending-posts://list or pending-posts://{id}
+  const match = uri.match(/^pending-posts:\/\/(.+)$/);
+  if (!match) {
+    throw new Error(
+      `Invalid pending-posts URI: ${uri}. Expected format: pending-posts://list or pending-posts://{id}`
+    );
+  }
+
+  const param = match[1];
+
+  // List all pending posts
+  if (param === 'list') {
+    return readAllPendingPosts();
+  }
+
+  // Read specific post by ID
+  if (param.startsWith('post')) {
+    return readPostById(param);
+  }
+
+  throw new Error(
+    `Invalid pending-posts parameter: ${param}. Expected 'list' or post ID (post...)`
+  );
+}
+
+/**
+ * Read all pending posts
+ */
+function readAllPendingPosts(): string {
+  const posts = getPendingPosts();
+
+  if (posts.length === 0) {
+    return JSON.stringify(
+      {
+        posts: [],
+        total: 0,
+        message: 'No pending posts found',
+      },
+      null,
+      2
+    );
+  }
+
+  return JSON.stringify(
+    {
+      posts: posts.map(post => ({
+        id: post.id,
+        insightId: post.insightId,
+        platform: post.platform,
+        status: post.status,
+        version: post.version,
+        createdAt: post.createdAt,
+        contentPreview: getContentPreview(post.content, post.platform),
+        metadata: post.metadata,
+      })),
+      total: posts.length,
+    },
+    null,
+    2
+  );
+}
+
+/**
+ * Read specific post by ID
+ */
+function readPostById(id: string): string {
+  const post = getSNSPost(id);
+
+  if (!post) {
+    return JSON.stringify(
+      {
+        error: `Post not found: ${id}`,
+      },
+      null,
+      2
+    );
+  }
+
+  return JSON.stringify(
+    {
+      id: post.id,
+      insightId: post.insightId,
+      platform: post.platform,
+      content: post.content,
+      status: post.status,
+      version: post.version,
+      parentId: post.parentId,
+      createdAt: post.createdAt,
+      approvedAt: post.approvedAt,
+      publishedAt: post.publishedAt,
+      publishedUrl: post.publishedUrl,
+      metadata: post.metadata,
+    },
+    null,
+    2
+  );
+}
+
+/**
+ * Get content preview
+ */
+function getContentPreview(
+  content: string | string[],
+  platform: 'thread' | 'linkedin' | 'medium'
+): string {
+  if (Array.isArray(content)) {
+    // Thread: show first tweet
+    const firstTweet = content[0] || '';
+    return firstTweet.substring(0, 100) + (firstTweet.length > 100 ? '...' : '');
+  }
+
+  // LinkedIn/Medium: show first 200 chars
+  const text = String(content);
+  return text.substring(0, 200) + (text.length > 200 ? '...' : '');
+}


### PR DESCRIPTION
Implements MCP resource for accessing pending SNS posts.

Changes:
- Add pending-posts.ts resource implementation
  - List all pending posts with previews
  - Read specific post by ID with full content
  - Return JSON format
  - Content preview generation (first 100-200 chars)
- Register pending-posts resource in MCP server
  - Add to ListResourcesRequestSchema handler
  - Add to ReadResourceRequestSchema handler
- Support two URI formats:
  - pending-posts://list: Get all pending posts
  - pending-posts://{id}: Get specific post details
- List view includes:
  - Post ID, insight ID, platform
  - Status, version, created timestamp
  - Content preview
  - Metadata (hashtags, counts)
- Detail view includes:
  - Full content (string or array for threads)
  - All timestamps (created, approved, published)
  - Published URL if available
  - Parent ID for revised posts

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>