### PR TITLE
Issue #23: log_daily_work Tool Update

### DIFF
--- a/src/storage/db.ts
+++ b/src/storage/db.ts
@@ -243,6 +243,35 @@ export function getDailyLog(id: string): Partial<DailyLog> | null {
   };
 }
 
+export function updateDailyLog(id: string, updates: Partial<DailyLog>): void {
+  const database = getDatabase();
+  const fields: string[] = [];
+  const values: any[] = [];
+
+  if (updates.notionPageId !== undefined) {
+    fields.push('notion_page_id = ?');
+    values.push(updates.notionPageId);
+  }
+
+  if (updates.summary !== undefined) {
+    fields.push('summary = ?');
+    values.push(updates.summary);
+  }
+
+  if (updates.manualNotes !== undefined) {
+    fields.push('manual_notes = ?');
+    values.push(updates.manualNotes);
+  }
+
+  if (fields.length === 0) {
+    return; // No updates
+  }
+
+  values.push(id);
+  const stmt = database.prepare(`UPDATE daily_logs SET ${fields.join(', ')} WHERE id = ?`);
+  stmt.run(...values);
+}
+
 export function getDailyLogsByDateRange(startDate: string, endDate: string): Partial<DailyLog>[] {
   const database = getDatabase();
   const stmt = database.prepare('SELECT * FROM daily_logs WHERE date >= ? AND date <= ? ORDER BY date DESC');

--- a/src/tools/log-daily-work.ts
+++ b/src/tools/log-daily-work.ts
@@ -11,7 +11,9 @@
 
 import { analyzeGitCommits } from '../core/git-analyzer.js';
 import { ObsidianFileManager } from '../integrations/obsidian/file-manager.js';
-import { createDailyLog, getProject, createActionItem } from '../storage/db.js';
+import { NotionClient } from '../integrations/notion/client.js';
+import { buildDailyLogPage } from '../integrations/notion/page-builder.js';
+import { createDailyLog, getProject, createActionItem, updateDailyLog } from '../storage/db.js';
 import type { Config } from '../types/index.js';
 import type { GitCommit } from '../types/index.js';
 
@@ -123,8 +125,44 @@ export async function logDailyWorkTool(
     });
   }
 
-  // TODO: Create Notion page in Issue #23
-  const notionPageId = undefined;
+  // Create Notion page (dual write)
+  let notionPageId: string | undefined;
+  try {
+    if (project.notionPageId) {
+      const notionClient = new NotionClient({
+        token: config.notion.token,
+        parentPageId: config.notion.parentPageId,
+      });
+
+      // Build Notion page data
+      const pageData = buildDailyLogPage({
+        date,
+        projectName: project.name,
+        summary,
+        commits,
+        manualNotes: manualInput,
+        actionItems,
+      });
+
+      // Create page in project's Notion database
+      const notionResult = await notionClient.createPage({
+        databaseId: project.notionPageId,
+        properties: pageData.properties,
+        content: pageData.content,
+      });
+
+      notionPageId = notionResult.pageId;
+      console.error(`  - Notion page created: ${notionResult.url}`);
+
+      // Update database with Notion page ID
+      updateDailyLog(logId, { notionPageId });
+    } else {
+      console.error('  - Skipping Notion (project has no Notion database)');
+    }
+  } catch (error) {
+    console.error('  - Warning: Failed to create Notion page:', error);
+    // Continue without Notion page (don't fail the entire operation)
+  }
 
   return {
     logId,
@@ -132,7 +170,7 @@ export async function logDailyWorkTool(
     notionPageId,
     commitCount: commits.length,
     actionItems,
-    message: `Daily log created for ${date}!\n- Log ID: ${logId}\n- Commits: ${commits.length}\n- Action items: ${actionItems.length}\n- Obsidian: ${obsidianPath}`,
+    message: `Daily log created for ${date}!\n- Log ID: ${logId}\n- Commits: ${commits.length}\n- Action items: ${actionItems.length}\n- Obsidian: ${obsidianPath}${notionPageId ? `\n- Notion: Created (${notionPageId})` : ''}`,
   };
 }
 


### PR DESCRIPTION
Updates log_daily_work tool to support Notion dual write.

Changes:
- Update log-daily-work.ts:
  - Import NotionClient and buildDailyLogPage
  - Create Notion page after Obsidian file
  - Check if project has Notion database (project.notionPageId)
  - Build page data with buildDailyLogPage
  - Create page in project's Notion database
  - Store Notion page ID in database via updateDailyLog
  - Add error handling: Continue without Notion on failure
  - Update result message with Notion page ID
- Add updateDailyLog to db.ts:
  - Update daily log fields dynamically
  - Support notionPageId, summary, manualNotes updates
  - Build SQL dynamically based on provided fields
  - Export function for use in tools

Dual write workflow:
1. Create Obsidian markdown file (existing)
2. Create Notion page if project has database
3. Update database with both paths
4. Return both IDs in result message

Error handling:
- Skip Notion if project has no database
- Catch Notion errors and log warning
- Continue with Obsidian-only on Notion failure
- Don't fail entire operation due to Notion errors

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>