### PR TITLE
Issue #24: create_project Tool Update

### DIFF
--- a/src/storage/db.ts
+++ b/src/storage/db.ts
@@ -186,6 +186,35 @@ export function getProject(id: string): Project | null {
   };
 }
 
+export function updateProject(id: string, updates: Partial<Project>): void {
+  const database = getDatabase();
+  const fields: string[] = [];
+  const values: any[] = [];
+
+  if (updates.notionPageId !== undefined) {
+    fields.push('notion_page_id = ?');
+    values.push(updates.notionPageId);
+  }
+
+  if (updates.description !== undefined) {
+    fields.push('description = ?');
+    values.push(updates.description);
+  }
+
+  if (updates.name !== undefined) {
+    fields.push('name = ?');
+    values.push(updates.name);
+  }
+
+  if (fields.length === 0) {
+    return; // No updates
+  }
+
+  values.push(id);
+  const stmt = database.prepare(`UPDATE projects SET ${fields.join(', ')} WHERE id = ?`);
+  stmt.run(...values);
+}
+
 export function getAllProjects(): Project[] {
   const database = getDatabase();
   const stmt = database.prepare('SELECT * FROM projects ORDER BY created_at DESC');

--- a/src/tools/create-project.ts
+++ b/src/tools/create-project.ts
@@ -11,7 +11,9 @@ import { mkdirSync, writeFileSync, existsSync } from 'fs';
 import { resolve, join } from 'path';
 import Mustache from 'mustache';
 import { readFileSync } from 'fs';
-import { createProject } from '../storage/db.js';
+import { createProject, updateProject } from '../storage/db.js';
+import { NotionClient } from '../integrations/notion/client.js';
+import { buildProjectDatabaseProperties } from '../integrations/notion/page-builder.js';
 import type { Config } from '../types/index.js';
 
 export interface CreateProjectParams {
@@ -61,8 +63,31 @@ export async function createProjectTool(
     obsidianPath,
   });
 
-  // TODO: Create Notion database in Issue #24
-  const notionPageId = undefined;
+  // Create Notion database
+  let notionPageId: string | undefined;
+  let notionUrl: string | undefined;
+  try {
+    const notionClient = new NotionClient({
+      token: config.notion.token,
+      parentPageId: config.notion.parentPageId,
+    });
+
+    // Create database for daily logs
+    const notionResult = await notionClient.createDatabase({
+      title: projectName,
+      properties: buildProjectDatabaseProperties(),
+    });
+
+    notionPageId = notionResult.databaseId;
+    notionUrl = notionResult.url;
+    console.error(`  - Created Notion database: ${notionUrl}`);
+
+    // Update project with Notion database ID
+    updateProject(projectId, { notionPageId });
+  } catch (error) {
+    console.error('  - Warning: Failed to create Notion database:', error);
+    // Continue without Notion database (don't fail the entire operation)
+  }
 
   // TODO: Implement conversation mode in Issue #25
   if (conversationMode) {
@@ -73,7 +98,7 @@ export async function createProjectTool(
     projectId,
     obsidianPath,
     notionPageId,
-    message: `Project "${projectName}" created successfully!\n- ID: ${projectId}\n- Obsidian: ${obsidianPath}`,
+    message: `Project "${projectName}" created successfully!\n- ID: ${projectId}\n- Obsidian: ${obsidianPath}${notionPageId ? `\n- Notion: ${notionUrl}` : ''}`,
   };
 }
 


### PR DESCRIPTION
Updates create_project tool to create Notion databases for projects.

Changes:
- Update create-project.ts:
  - Import NotionClient and buildProjectDatabaseProperties
  - Create Notion database after SQLite entry
  - Use buildProjectDatabaseProperties for schema
  - Store database ID via updateProject
  - Add error handling: Continue without Notion on failure
  - Update result message with Notion URL
- Add updateProject to db.ts:
  - Update project fields dynamically
  - Support notionPageId, description, name updates
  - Build SQL dynamically based on provided fields
  - Export function for use in tools

Notion database structure:
- Each project gets its own Notion database
- Database contains daily log pages
- Properties: Name (title), Date, Summary, Commits count
- Created under configured parent page

Workflow:
1. Create Obsidian directory with README
2. Create SQLite project record
3. Create Notion database for daily logs
4. Update project with Notion database ID
5. Return project ID, Obsidian path, Notion database ID

Error handling:
- Catch Notion errors and log warning
- Continue with Obsidian-only on Notion failure
- Don't fail entire operation due to Notion errors

Integration:
- log_daily_work will create pages in this database
- Database ID stored in project.notionPageId

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>