### PR TITLE
Issue #25: Remaining MCP Prompts

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -27,6 +27,8 @@ import { generateSNSTool, type GenerateSNSParams } from './tools/generate-sns.js
 import { approveAndPublishTool, type ApproveAndPublishParams } from './tools/approve-publish.js';
 import { listInsightsResources, readInsightsResource } from './resources/insights.js';
 import { listPendingPostsResources, readPendingPostsResource } from './resources/pending-posts.js';
+import { getDailyStandupPrompt } from './prompts/daily-standup.js';
+import { getProjectIdeationPrompt } from './prompts/project-ideation.js';
 import type { Config } from './types/index.js';
 
 /**
@@ -400,21 +402,70 @@ async function main() {
   server.setRequestHandler(ListPromptsRequestSchema, async () => {
     return {
       prompts: [
-        // TODO: Add prompts in subsequent issues
-        // - daily-standup (Issue #25)
-        // - project-ideation (Issue #25)
-        // - insight-extraction (Issue #10)
-        // - sns-formatters (Issue #13)
+        {
+          name: 'daily-standup',
+          description: 'Generate daily standup summary from recent logs',
+          arguments: [
+            {
+              name: 'date',
+              description: 'End date for standup (YYYY-MM-DD, defaults to today)',
+              required: false,
+            },
+            {
+              name: 'projectId',
+              description: 'Filter by specific project ID',
+              required: false,
+            },
+            {
+              name: 'daysBack',
+              description: 'Number of days to look back (default: 1)',
+              required: false,
+            },
+          ],
+        },
+        {
+          name: 'project-ideation',
+          description: 'Interactive brainstorming session for new projects',
+          arguments: [
+            {
+              name: 'topic',
+              description: 'Project topic or area (e.g., "web app", "CLI tool")',
+              required: false,
+            },
+            {
+              name: 'constraints',
+              description: 'List of constraints or requirements',
+              required: false,
+            },
+            {
+              name: 'goals',
+              description: 'List of project goals',
+              required: false,
+            },
+          ],
+        },
       ],
     };
   });
 
   // Register prompt get handler
   server.setRequestHandler(GetPromptRequestSchema, async (request) => {
-    const { name } = request.params;
+    const { name, arguments: args } = request.params;
 
-    // TODO: Implement prompt handlers in subsequent issues
-    throw new Error(`Unknown prompt: ${name}`);
+    try {
+      if (name === 'daily-standup') {
+        return await getDailyStandupPrompt(args as any);
+      }
+
+      if (name === 'project-ideation') {
+        return await getProjectIdeationPrompt(args as any);
+      }
+
+      throw new Error(`Unknown prompt: ${name}`);
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      throw new Error(`Failed to get prompt: ${errorMessage}`);
+    }
   });
 
   // Start server with stdio transport

--- a/src/prompts/daily-standup.ts
+++ b/src/prompts/daily-standup.ts
@@ -1,0 +1,71 @@
+/**
+ * Daily Standup Prompt
+ *
+ * MCP prompt for generating daily standup summaries from logs
+ */
+
+import { getDailyLogsByDateRange } from '../storage/db.js';
+
+export const DAILY_STANDUP_PROMPT_NAME = 'daily-standup';
+
+export const DAILY_STANDUP_PROMPT_DESCRIPTION =
+  'Generate a daily standup summary from recent logs';
+
+/**
+ * Get daily standup prompt
+ */
+export async function getDailyStandupPrompt(args?: {
+  date?: string;
+  projectId?: string;
+  daysBack?: number;
+}): Promise<{ messages: Array<{ role: string; content: { type: string; text: string } }> }> {
+  const date = args?.date || new Date().toISOString().split('T')[0];
+  const daysBack = args?.daysBack || 1;
+  const projectId = args?.projectId;
+
+  // Calculate date range
+  const endDate = new Date(date);
+  const startDate = new Date(endDate);
+  startDate.setDate(startDate.getDate() - daysBack);
+
+  const startDateStr = startDate.toISOString().split('T')[0];
+  const endDateStr = endDate.toISOString().split('T')[0];
+
+  // Get logs
+  let logs = getDailyLogsByDateRange(startDateStr, endDateStr);
+
+  // Filter by project if specified
+  if (projectId) {
+    logs = logs.filter(log => log.projectId === projectId);
+  }
+
+  // Build context
+  const logsContext = logs.length > 0
+    ? logs.map(log => `**${log.date}** (${log.projectId}):\n${log.summary}`).join('\n\n')
+    : 'No logs found for this period.';
+
+  const promptText = `Based on the following dev logs, create a concise daily standup summary.
+
+**Logs from ${startDateStr} to ${endDateStr}:**
+
+${logsContext}
+
+**Please provide:**
+1. **What was done**: Key accomplishments (2-3 bullet points)
+2. **Challenges**: Any blockers or issues encountered
+3. **Next steps**: What's planned next (1-2 items)
+
+Keep it brief and focused on the most important points.`;
+
+  return {
+    messages: [
+      {
+        role: 'user',
+        content: {
+          type: 'text',
+          text: promptText,
+        },
+      },
+    ],
+  };
+}

--- a/src/prompts/project-ideation.ts
+++ b/src/prompts/project-ideation.ts
@@ -1,0 +1,58 @@
+/**
+ * Project Ideation Prompt
+ *
+ * MCP prompt for conversational project ideation and brainstorming
+ */
+
+export const PROJECT_IDEATION_PROMPT_NAME = 'project-ideation';
+
+export const PROJECT_IDEATION_PROMPT_DESCRIPTION =
+  'Interactive brainstorming session for new project ideas';
+
+/**
+ * Get project ideation prompt
+ */
+export async function getProjectIdeationPrompt(args?: {
+  topic?: string;
+  constraints?: string[];
+  goals?: string[];
+}): Promise<{ messages: Array<{ role: string; content: { type: string; text: string } }> }> {
+  const topic = args?.topic || 'new software project';
+  const constraints = args?.constraints || [];
+  const goals = args?.goals || [];
+
+  let promptText = `Let's brainstorm ideas for a ${topic}.
+
+I'll help you explore different angles, validate ideas, and structure your thoughts.`;
+
+  if (constraints.length > 0) {
+    promptText += `\n\n**Constraints to consider:**\n${constraints.map(c => `- ${c}`).join('\n')}`;
+  }
+
+  if (goals.length > 0) {
+    promptText += `\n\n**Goals:**\n${goals.map(g => `- ${g}`).join('\n')}`;
+  }
+
+  promptText += `\n\n**I can help you with:**
+
+1. **Idea Generation**: Brainstorm potential approaches and features
+2. **Technical Stack**: Discuss appropriate technologies
+3. **Architecture**: Outline high-level system design
+4. **MVP Scope**: Define minimum viable product
+5. **Challenges**: Identify potential roadblocks early
+6. **Next Steps**: Create actionable plan
+
+What aspect would you like to start with, or do you have a specific idea you'd like to explore?`;
+
+  return {
+    messages: [
+      {
+        role: 'user',
+        content: {
+          type: 'text',
+          text: promptText,
+        },
+      },
+    ],
+  };
+}


### PR DESCRIPTION
Implements remaining MCP prompts for daily standup and project ideation.

Changes:
- Add daily-standup.ts prompt:
  - Generate concise standup summary from logs
  - Query logs by date range
  - Optional project filtering
  - Configurable days back parameter
  - Returns 3-part summary (Done, Challenges, Next)
- Add project-ideation.ts prompt:
  - Interactive brainstorming session
  - Guide through project planning
  - Support topic, constraints, goals
  - Cover idea generation, tech stack, architecture, MVP
- Register prompts in MCP server:
  - Add schemas to ListPromptsRequestSchema
  - Implement handlers in GetPromptRequestSchema
  - Define argument schemas for each prompt

Prompt usage:
- daily-standup: Quick team updates from dev logs
- project-ideation: Conversational project planning

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>