### PR TITLE
Add test suite - 47 passing tests (Issue #30)

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,24 @@
+/** @type {import('ts-jest').JestConfigWithTsJest} */
+export default {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  extensionsToTreatAsEsm: [],
+  moduleNameMapper: {
+    '^(\\.{1,2}/.*)\\.js$': '$1',
+  },
+  transform: {
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        tsconfig: 'tsconfig.test.json',
+      },
+    ],
+  },
+  testMatch: ['**/src/__tests__/**/*.test.ts'],
+  collectCoverageFrom: [
+    'src/**/*.ts',
+    '!src/index.ts',
+    '!src/setup.ts',
+    '!src/**/*.d.ts',
+  ],
+};

--- a/src/__tests__/action-extraction.test.ts
+++ b/src/__tests__/action-extraction.test.ts
@@ -1,0 +1,38 @@
+/**
+ * Unit tests for action extraction prompt helpers and parser logic.
+ * Tests the formatting and parsing functions without Claude API calls.
+ */
+
+import { formatLogsForActionExtraction } from '../prompts/action-extraction';
+
+describe('formatLogsForActionExtraction', () => {
+  it('formats a single log with date and summary', () => {
+    const result = formatLogsForActionExtraction([
+      { date: '2026-03-20', summary: 'Fixed auth bug' },
+    ]);
+    expect(result).toContain('[2026-03-20]');
+    expect(result).toContain('Fixed auth bug');
+  });
+
+  it('includes manual notes when present', () => {
+    const result = formatLogsForActionExtraction([
+      { date: '2026-03-20', summary: 'Refactored DB layer', manualNotes: 'TODO: add indexes' },
+    ]);
+    expect(result).toContain('Notes: TODO: add indexes');
+  });
+
+  it('separates multiple logs with a divider', () => {
+    const result = formatLogsForActionExtraction([
+      { date: '2026-03-19', summary: 'First log' },
+      { date: '2026-03-20', summary: 'Second log' },
+    ]);
+    expect(result).toContain('---');
+    expect(result).toContain('[2026-03-19]');
+    expect(result).toContain('[2026-03-20]');
+  });
+
+  it('returns empty string for empty input', () => {
+    const result = formatLogsForActionExtraction([]);
+    expect(result).toBe('');
+  });
+});

--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Unit tests for configuration loading and validation.
+ * Uses temp files to avoid touching the real config.
+ */
+
+import { writeFileSync, unlinkSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { loadConfig } from '../utils/config';
+
+function writeTempConfig(content: object): string {
+  const path = join(tmpdir(), `retrospect-test-${Date.now()}.json`);
+  writeFileSync(path, JSON.stringify(content), 'utf-8');
+  return path;
+}
+
+describe('loadConfig', () => {
+  const originalEnv = { ...process.env };
+
+  afterEach(() => {
+    // Restore env vars after each test
+    process.env = { ...originalEnv };
+  });
+
+  it('loads minimal required config (Claude + Obsidian)', () => {
+    process.env.CLAUDE_API_KEY = 'sk-test-key';
+    process.env.OBSIDIAN_VAULT_PATH = '/tmp/vault';
+    process.env.DATABASE_PATH = '/tmp/test.db';
+    process.env.DEFAULT_GIT_REPO_PATH = '';
+    // Clear all optional vars so they are not picked up from .env
+    delete process.env.NOTION_TOKEN;
+    delete process.env.NOTION_PARENT_PAGE_ID;
+    delete process.env.TWITTER_BEARER_TOKEN;
+    delete process.env.TWITTER_API_KEY;
+    delete process.env.TWITTER_API_SECRET;
+    delete process.env.TWITTER_ACCESS_TOKEN;
+    delete process.env.TWITTER_ACCESS_SECRET;
+    delete process.env.LINKEDIN_ACCESS_TOKEN;
+    delete process.env.LINKEDIN_USER_ID;
+    delete process.env.MEDIUM_TOKEN;
+
+    const configPath = writeTempConfig({
+      obsidian: { vaultPath: '${OBSIDIAN_VAULT_PATH}' },
+      notion: { token: '${NOTION_TOKEN}', parentPageId: '${NOTION_PARENT_PAGE_ID}' },
+      claude: { apiKey: '${CLAUDE_API_KEY}', model: 'claude-sonnet-4-6' },
+      sns: {
+        thread: { bearerToken: '${TWITTER_BEARER_TOKEN}' },
+        linkedin: { accessToken: '${LINKEDIN_ACCESS_TOKEN}', userId: '${LINKEDIN_USER_ID}' },
+        medium: { token: '${MEDIUM_TOKEN}' },
+      },
+      git: { defaultRepoPath: '${DEFAULT_GIT_REPO_PATH}' },
+      database: { path: '${DATABASE_PATH}' },
+    });
+
+    try {
+      const config = loadConfig(configPath);
+      expect(config.claude.apiKey).toBe('sk-test-key');
+      expect(config.obsidian.vaultPath).toBe('/tmp/vault');
+      // Optional sections should be stripped
+      expect(config.notion).toBeUndefined();
+      expect(config.sns).toBeUndefined();
+    } finally {
+      unlinkSync(configPath);
+    }
+  });
+
+  it('includes notion config when token is set', () => {
+    process.env.CLAUDE_API_KEY = 'sk-test-key';
+    process.env.OBSIDIAN_VAULT_PATH = '/tmp/vault';
+    process.env.DATABASE_PATH = '/tmp/test.db';
+    process.env.DEFAULT_GIT_REPO_PATH = '';
+    process.env.NOTION_TOKEN = 'secret_abc';
+    process.env.NOTION_PARENT_PAGE_ID = 'page-123';
+
+    const configPath = writeTempConfig({
+      obsidian: { vaultPath: '${OBSIDIAN_VAULT_PATH}' },
+      notion: { token: '${NOTION_TOKEN}', parentPageId: '${NOTION_PARENT_PAGE_ID}' },
+      claude: { apiKey: '${CLAUDE_API_KEY}', model: 'claude-sonnet-4-6' },
+      git: { defaultRepoPath: '${DEFAULT_GIT_REPO_PATH}' },
+      database: { path: '${DATABASE_PATH}' },
+    });
+
+    try {
+      const config = loadConfig(configPath);
+      expect(config.notion).toBeDefined();
+      expect(config.notion!.token).toBe('secret_abc');
+      expect(config.notion!.parentPageId).toBe('page-123');
+    } finally {
+      unlinkSync(configPath);
+    }
+  });
+
+  it('throws when Claude API key is missing', () => {
+    delete process.env.CLAUDE_API_KEY;
+    process.env.OBSIDIAN_VAULT_PATH = '/tmp/vault';
+
+    const configPath = writeTempConfig({
+      obsidian: { vaultPath: '${OBSIDIAN_VAULT_PATH}' },
+      claude: { apiKey: '${CLAUDE_API_KEY}', model: 'claude-sonnet-4-6' },
+      git: { defaultRepoPath: '' },
+      database: { path: '/tmp/test.db' },
+    });
+
+    try {
+      expect(() => loadConfig(configPath)).toThrow('Invalid configuration');
+    } finally {
+      unlinkSync(configPath);
+    }
+  });
+
+  it('throws when Obsidian vault path is missing', () => {
+    process.env.CLAUDE_API_KEY = 'sk-test-key';
+    delete process.env.OBSIDIAN_VAULT_PATH;
+
+    const configPath = writeTempConfig({
+      obsidian: { vaultPath: '${OBSIDIAN_VAULT_PATH}' },
+      claude: { apiKey: '${CLAUDE_API_KEY}', model: 'claude-sonnet-4-6' },
+      git: { defaultRepoPath: '' },
+      database: { path: '/tmp/test.db' },
+    });
+
+    try {
+      expect(() => loadConfig(configPath)).toThrow('Invalid configuration');
+    } finally {
+      unlinkSync(configPath);
+    }
+  });
+});

--- a/src/__tests__/db.test.ts
+++ b/src/__tests__/db.test.ts
@@ -1,0 +1,211 @@
+import { initializeDatabase, createProject, getProject, updateProject, getAllProjects,
+  createDailyLog, getDailyLog, getDailyLogsByDateRange,
+  createInsight, getInsight, getInsightsByDate,
+  createSNSPost, getSNSPost, getPendingPosts, updateSNSPostStatus,
+  createActionItem, getActionItemsByLog, updateActionItemCompleted,
+} from '../storage/db';
+
+// Use a shared in-memory DB for the test suite
+const TEST_DB_PATH = ':memory:';
+
+beforeAll(() => {
+  initializeDatabase(TEST_DB_PATH);
+});
+
+// ─── Projects ────────────────────────────────────────────────────────────────
+describe('Project CRUD', () => {
+  let projectId: string;
+
+  it('creates a project and returns an id', () => {
+    projectId = createProject({
+      name: 'Test Project',
+      description: 'A test project',
+      createdDate: '2026-03-20',
+      obsidianPath: '/vault/test',
+    });
+    expect(projectId).toMatch(/^prj_/);
+  });
+
+  it('retrieves the created project', () => {
+    const project = getProject(projectId);
+    expect(project).not.toBeNull();
+    expect(project!.name).toBe('Test Project');
+    expect(project!.description).toBe('A test project');
+  });
+
+  it('updates a project field', () => {
+    updateProject(projectId, { notionPageId: 'notion-db-abc' });
+    const project = getProject(projectId);
+    expect(project!.notionPageId).toBe('notion-db-abc');
+  });
+
+  it('returns null for non-existent project', () => {
+    expect(getProject('prj_doesnotexist')).toBeNull();
+  });
+
+  it('lists all projects', () => {
+    const projects = getAllProjects();
+    expect(projects.length).toBeGreaterThan(0);
+    expect(projects.some((p) => p.id === projectId)).toBe(true);
+  });
+});
+
+// ─── Daily Logs ──────────────────────────────────────────────────────────────
+describe('Daily Log CRUD', () => {
+  let logId: string;
+  let projectId: string;
+
+  beforeAll(() => {
+    projectId = createProject({
+      name: 'Log Test Project',
+      createdDate: '2026-03-20',
+      obsidianPath: '/vault/log-test',
+    });
+  });
+
+  it('creates a daily log', () => {
+    logId = createDailyLog({
+      date: '2026-03-20',
+      projectId,
+      summary: 'Fixed bug in auth middleware',
+      obsidianPath: '/vault/log-test/2026-03-20.md',
+      actionItems: ['Write tests', 'Update docs'],
+    });
+    expect(logId).toMatch(/^log_/);
+  });
+
+  it('retrieves the daily log', () => {
+    const log = getDailyLog(logId);
+    expect(log).not.toBeNull();
+    expect(log!.summary).toBe('Fixed bug in auth middleware');
+    expect(log!.date).toBe('2026-03-20');
+  });
+
+  it('queries logs by date range', () => {
+    const logs = getDailyLogsByDateRange('2026-03-19', '2026-03-21');
+    expect(logs.length).toBeGreaterThan(0);
+    expect(logs.some((l) => l.id === logId)).toBe(true);
+  });
+
+  it('returns empty array for out-of-range date', () => {
+    const logs = getDailyLogsByDateRange('2020-01-01', '2020-01-02');
+    expect(logs).toHaveLength(0);
+  });
+});
+
+// ─── Insights ─────────────────────────────────────────────────────────────────
+describe('Insight CRUD', () => {
+  let insightId: string;
+
+  it('creates an insight', () => {
+    insightId = createInsight({
+      date: '2026-03-20',
+      content: 'Using prepared statements prevents SQL injection',
+      category: 'tooling',
+      confidence: 0.9,
+      sourceLogIds: ['log_abc'],
+    });
+    expect(insightId).toMatch(/^ins_/);
+  });
+
+  it('retrieves the insight', () => {
+    const insight = getInsight(insightId);
+    expect(insight).not.toBeNull();
+    expect(insight!.content).toBe('Using prepared statements prevents SQL injection');
+    expect(insight!.confidence).toBe(0.9);
+  });
+
+  it('queries insights by date', () => {
+    const insights = getInsightsByDate('2026-03-20');
+    expect(insights.some((i) => i.id === insightId)).toBe(true);
+  });
+});
+
+// ─── SNS Posts ────────────────────────────────────────────────────────────────
+describe('SNS Post CRUD', () => {
+  let insightId: string;
+  let postId: string;
+
+  beforeAll(() => {
+    insightId = createInsight({
+      date: '2026-03-20',
+      content: 'SNS test insight',
+      category: 'other',
+      confidence: 0.8,
+      sourceLogIds: [],
+    });
+  });
+
+  it('creates a pending post', () => {
+    postId = createSNSPost({
+      insightId,
+      platform: 'linkedin',
+      content: 'My LinkedIn post content',
+      status: 'pending',
+      version: 1,
+    });
+    expect(postId).toMatch(/^post_/);
+  });
+
+  it('retrieves the post', () => {
+    const post = getSNSPost(postId);
+    expect(post).not.toBeNull();
+    expect(post!.platform).toBe('linkedin');
+    expect(post!.status).toBe('pending');
+  });
+
+  it('lists pending posts', () => {
+    const pending = getPendingPosts();
+    expect(pending.some((p) => p.id === postId)).toBe(true);
+  });
+
+  it('updates post status to published', () => {
+    updateSNSPostStatus(postId, 'published', 'https://linkedin.com/post/123');
+    const post = getSNSPost(postId);
+    expect(post!.status).toBe('published');
+    expect(post!.publishedUrl).toBe('https://linkedin.com/post/123');
+  });
+});
+
+// ─── Action Items ─────────────────────────────────────────────────────────────
+describe('Action Item CRUD', () => {
+  let logId: string;
+  let projectId: string;
+
+  beforeAll(() => {
+    projectId = createProject({
+      name: 'Action Test Project',
+      createdDate: '2026-03-20',
+      obsidianPath: '/vault/action-test',
+    });
+    logId = createDailyLog({
+      date: '2026-03-20',
+      projectId,
+      summary: 'Test log for action items',
+      obsidianPath: '/vault/action-test/2026-03-20.md',
+      actionItems: [],
+    });
+  });
+
+  it('creates action items', () => {
+    const id = createActionItem({ logId, content: 'Fix auth bug', priority: 'high', completed: false });
+    expect(id).toMatch(/^act_/);
+    createActionItem({ logId, content: 'Add unit tests', priority: 'medium', completed: false });
+  });
+
+  it('lists action items by log', () => {
+    const items = getActionItemsByLog(logId);
+    expect(items).toHaveLength(2);
+    const priorities = items.map((i) => i.priority);
+    expect(priorities).toContain('high');
+    expect(priorities).toContain('medium');
+  });
+
+  it('marks an item as completed', () => {
+    const items = getActionItemsByLog(logId);
+    updateActionItemCompleted(items[0].id, true);
+    const updated = getActionItemsByLog(logId);
+    const completedItem = updated.find((i) => i.id === items[0].id);
+    expect(completedItem!.completed).toBe(true);
+  });
+});

--- a/src/__tests__/errors.test.ts
+++ b/src/__tests__/errors.test.ts
@@ -1,0 +1,43 @@
+import {
+  ConfigError,
+  NotConfiguredError,
+  ValidationError,
+  NotFoundError,
+  ExternalApiError,
+} from '../utils/errors';
+
+describe('Custom Error Types', () => {
+  it('ConfigError has correct name and message', () => {
+    const err = new ConfigError('missing key');
+    expect(err.name).toBe('ConfigError');
+    expect(err.message).toBe('missing key');
+    expect(err).toBeInstanceOf(Error);
+  });
+
+  it('NotConfiguredError includes setup hint', () => {
+    const err = new NotConfiguredError('Notion');
+    expect(err.name).toBe('NotConfiguredError');
+    expect(err.message).toContain('Notion');
+    expect(err.message).toContain('npm run setup');
+  });
+
+  it('ValidationError has correct name', () => {
+    const err = new ValidationError('invalid date format');
+    expect(err.name).toBe('ValidationError');
+    expect(err.message).toBe('invalid date format');
+  });
+
+  it('NotFoundError formats entity and id', () => {
+    const err = new NotFoundError('Project', 'prj_abc123');
+    expect(err.name).toBe('NotFoundError');
+    expect(err.message).toBe('Project not found: prj_abc123');
+  });
+
+  it('ExternalApiError includes service name', () => {
+    const err = new ExternalApiError('Claude', 'rate limit exceeded', 429);
+    expect(err.name).toBe('ExternalApiError');
+    expect(err.message).toContain('Claude');
+    expect(err.message).toContain('rate limit exceeded');
+    expect(err.statusCode).toBe(429);
+  });
+});

--- a/src/__tests__/insight-extractor.test.ts
+++ b/src/__tests__/insight-extractor.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Unit tests for the insight extractor core module.
+ * Claude API is mocked — no network calls.
+ */
+
+import { extractInsights } from '../core/insight-extractor';
+import type { ClaudeClient } from '../utils/claude-client';
+
+function makeClient(responseText: string): ClaudeClient {
+  return {
+    generateText: jest.fn().mockResolvedValue({
+      text: responseText,
+      usage: { inputTokens: 100, outputTokens: 50 },
+    }),
+  } as unknown as ClaudeClient;
+}
+
+const sampleLogs = [
+  {
+    date: '2026-03-20',
+    projectId: 'prj_abc',
+    summary: 'Fixed a race condition in the connection pool by using mutex locks',
+    manualNotes: 'Learned that async/await hides race conditions in shared state',
+  },
+];
+
+describe('extractInsights', () => {
+  it('returns empty result when no logs provided', async () => {
+    const client = makeClient('[]');
+    const result = await extractInsights({ logs: [] }, client);
+    expect(result.insights).toHaveLength(0);
+    expect(result.totalAnalyzed).toBe(0);
+  });
+
+  it('parses valid JSON array from Claude response', async () => {
+    const mockResponse = JSON.stringify([
+      {
+        content: 'Use mutex locks to prevent race conditions in async connection pools',
+        category: 'debugging',
+        confidence: 0.92,
+        context: 'connection pool race condition fix',
+      },
+    ]);
+    const client = makeClient(mockResponse);
+    const result = await extractInsights({ logs: sampleLogs }, client);
+    expect(result.insights).toHaveLength(1);
+    expect(result.insights[0].category).toBe('debugging');
+    expect(result.insights[0].confidence).toBe(0.92);
+  });
+
+  it('filters insights below confidence threshold (0.6)', async () => {
+    const mockResponse = JSON.stringify([
+      { content: 'Low confidence insight that is long enough', category: 'other', confidence: 0.4, context: '' },
+      { content: 'High confidence insight that meets the minimum length', category: 'tooling', confidence: 0.85, context: '' },
+    ]);
+    const client = makeClient(mockResponse);
+    const result = await extractInsights({ logs: sampleLogs }, client);
+    expect(result.insights).toHaveLength(1);
+    expect(result.insights[0].confidence).toBe(0.85);
+  });
+
+  it('filters insights that are too short (< 20 chars)', async () => {
+    const mockResponse = JSON.stringify([
+      { content: 'Too short', category: 'other', confidence: 0.9, context: '' },
+      { content: 'This one is long enough to pass the minimum length check', category: 'tooling', confidence: 0.9, context: '' },
+    ]);
+    const client = makeClient(mockResponse);
+    const result = await extractInsights({ logs: sampleLogs }, client);
+    expect(result.insights).toHaveLength(1);
+  });
+
+  it('filters generic phrases', async () => {
+    const mockResponse = JSON.stringify([
+      { content: 'You should always write tests before shipping code to production', category: 'tooling', confidence: 0.9, context: '' },
+      { content: 'Instrument DB queries with EXPLAIN ANALYZE to find slow indexes', category: 'performance', confidence: 0.9, context: '' },
+    ]);
+    const client = makeClient(mockResponse);
+    const result = await extractInsights({ logs: sampleLogs }, client);
+    expect(result.insights).toHaveLength(1);
+    expect(result.insights[0].category).toBe('performance');
+  });
+
+  it('caps result at 5 insights', async () => {
+    const many = Array.from({ length: 8 }, (_, i) => ({
+      content: `Specific actionable insight number ${i + 1} with enough characters`,
+      category: 'other',
+      confidence: 0.9,
+      context: '',
+    }));
+    const client = makeClient(JSON.stringify(many));
+    const result = await extractInsights({ logs: sampleLogs }, client);
+    expect(result.insights.length).toBeLessThanOrEqual(5);
+  });
+
+  it('handles malformed JSON gracefully by throwing', async () => {
+    const client = makeClient('not json at all');
+    await expect(extractInsights({ logs: sampleLogs }, client)).rejects.toThrow();
+  });
+
+  it('normalises unknown category to "other"', async () => {
+    const mockResponse = JSON.stringify([
+      { content: 'Long enough insight text that should be categorised as other', category: 'unknown_category', confidence: 0.9, context: '' },
+    ]);
+    const client = makeClient(mockResponse);
+    const result = await extractInsights({ logs: sampleLogs }, client);
+    expect(result.insights[0].category).toBe('other');
+  });
+});

--- a/src/__tests__/logger.test.ts
+++ b/src/__tests__/logger.test.ts
@@ -1,0 +1,63 @@
+import { Logger, createLogger } from '../utils/logger';
+
+describe('Logger', () => {
+  let consoleSpy: jest.SpyInstance;
+  const originalLogLevel = process.env.LOG_LEVEL;
+
+  beforeEach(() => {
+    consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleSpy.mockRestore();
+    process.env.LOG_LEVEL = originalLogLevel;
+  });
+
+  it('creates a logger with a name', () => {
+    const log = createLogger('test');
+    expect(log).toBeInstanceOf(Logger);
+  });
+
+  it('writes info messages to stderr', () => {
+    process.env.LOG_LEVEL = 'info';
+    const log = createLogger('test');
+    log.info('hello world');
+    expect(consoleSpy).toHaveBeenCalledWith('[INFO] [test] hello world');
+  });
+
+  it('writes warn messages to stderr', () => {
+    process.env.LOG_LEVEL = 'info';
+    const log = createLogger('test');
+    log.warn('something wrong');
+    expect(consoleSpy).toHaveBeenCalledWith('[WARN] [test] something wrong');
+  });
+
+  it('writes error messages with Error object', () => {
+    const log = createLogger('test');
+    const err = new Error('boom');
+    log.error('failed', err);
+    expect(consoleSpy).toHaveBeenCalledWith('[ERROR] [test] failed: boom');
+  });
+
+  it('suppresses debug messages when LOG_LEVEL is info', () => {
+    process.env.LOG_LEVEL = 'info';
+    const log = createLogger('test');
+    log.debug('verbose detail');
+    expect(consoleSpy).not.toHaveBeenCalled();
+  });
+
+  it('shows debug messages when LOG_LEVEL is debug', () => {
+    process.env.LOG_LEVEL = 'debug';
+    const log = createLogger('test');
+    log.debug('verbose detail');
+    expect(consoleSpy).toHaveBeenCalledWith('[DEBUG] [test] verbose detail');
+  });
+
+  it('suppresses info when LOG_LEVEL is error', () => {
+    process.env.LOG_LEVEL = 'error';
+    const log = createLogger('test');
+    log.info('should be hidden');
+    log.warn('should be hidden');
+    expect(consoleSpy).not.toHaveBeenCalled();
+  });
+});

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -85,26 +85,36 @@ function substituteEnvVars(value: unknown): unknown {
 }
 
 /**
- * Strip optional config sections that have no values set.
- * Prevents Zod from failing on empty optional objects.
+ * Strip genuinely optional config sections (notion, sns) when they have no values.
+ * Required sections (obsidian, claude, git, database) are always preserved.
  */
+const OPTIONAL_SECTIONS = new Set(['notion', 'sns']);
+
 function stripEmpty(raw: Record<string, unknown>): Record<string, unknown> {
   const result: Record<string, unknown> = {};
 
   for (const [key, val] of Object.entries(raw)) {
     if (val === null || val === undefined) continue;
 
-    if (typeof val === 'object' && !Array.isArray(val)) {
-      const nested = val as Record<string, unknown>;
-      const allEmpty = Object.values(nested).every((v) => v === '' || v === null || v === undefined);
-      if (allEmpty) continue; // skip entirely so optional fields remain undefined
-      result[key] = stripEmpty(nested);
-    } else {
-      if (val !== '') result[key] = val;
+    if (OPTIONAL_SECTIONS.has(key) && typeof val === 'object' && !Array.isArray(val)) {
+      // Recursively check if all leaf values are empty
+      if (isDeepEmpty(val as Record<string, unknown>)) continue;
     }
+
+    result[key] = val;
   }
 
   return result;
+}
+
+function isDeepEmpty(obj: Record<string, unknown>): boolean {
+  return Object.values(obj).every((v) => {
+    if (v === null || v === undefined || v === '') return true;
+    if (typeof v === 'object' && !Array.isArray(v)) {
+      return isDeepEmpty(v as Record<string, unknown>);
+    }
+    return false;
+  });
 }
 
 /**

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "CommonJS",
+    "moduleResolution": "Node"
+  }
+}


### PR DESCRIPTION
## Summary

Jest 테스트 스위트 구축 — 6개 파일, 47개 테스트 전체 통과.

## Test Coverage

| 파일 | 대상 모듈 | 테스트 수 |
|------|-----------|-----------|
| `logger.test.ts` | `utils/logger` | 7 |
| `errors.test.ts` | `utils/errors` | 5 |
| `db.test.ts` | `storage/db` | 19 |
| `insight-extractor.test.ts` | `core/insight-extractor` | 8 |
| `action-extraction.test.ts` | `prompts/action-extraction` | 4 |
| `config.test.ts` | `utils/config` | 4 |

## Key Design Decisions

- **ts-jest + CommonJS mode** (`tsconfig.test.json`): ESM 호환 이슈 없이 안정적으로 동작
- **Claude API mock**: 네트워크 없이 insight-extractor 단위 테스트
- **In-memory SQLite** (`:memory:`): 격리된 DB 테스트, 파일 생성 없음
- **config.ts 버그픽스**: `stripEmpty()` 함수가 `git` 같은 필수 섹션까지 제거하던 문제 수정

## Test plan
- [x] `npm test` → 47/47 통과
- [x] `npm run build` → TypeScript 컴파일 에러 없음

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)